### PR TITLE
Setting hive.exec.dynamic.partition.mode=nonstrict

### DIFF
--- a/settings.hql
+++ b/settings.hql
@@ -1,2 +1,3 @@
 set hive.exec.max.dynamic.partitions.pernode=5000;
 set mapreduce.task.timeout=360000000;
+set hive.exec.dynamic.partition.mode=nonstrict;


### PR DESCRIPTION
If not set, user will run into the following when they try to create the ORC tables.
```
FAILED: SemanticException [Error 10096]: Dynamic partition strict mode requires at least one static partition column. To turn this off set hive.exec.dynamic.partition.mode=nonstrict
```